### PR TITLE
fixed signs for 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 	<repositories>
 		<!-- For spigot -->
 		<repository>
-			<id>md5-repo</id>
-			<url>http://repo.md-5.net/content/groups/public/</url>
+			<id>spigotmc-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -85,7 +85,7 @@
 		<!-- Spigot -->
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot</artifactId>
+			<artifactId>spigot-api</artifactId>
 			<version>${spigot.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/src/main/java/org/maxgamer/QuickShop/Shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/QuickShop/Shop/ShopManager.java
@@ -402,7 +402,7 @@ public class ShopManager {
                             }
                         }
                         signBlockState.setType(Material.OAK_WALL_SIGN);
-                        org.bukkit.block.data.type.WallSign signBlockDataType = (org.bukkit.block.data.type.WallSign) signBlockState.getBlockData();
+                        WallSign signBlockDataType = (WallSign) signBlockState.getBlockData();
                         signBlockDataType.setFacing(bf);
                         signBlockState.update(true);
                         shop.setSignText();

--- a/src/main/java/org/maxgamer/QuickShop/Shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/QuickShop/Shop/ShopManager.java
@@ -20,7 +20,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Attachable;
 import org.bukkit.material.Directional;
-import org.bukkit.material.Sign;
+import org.bukkit.block.data.type.WallSign;
 import org.bukkit.metadata.MetadataValue;
 import org.maxgamer.QuickShop.QuickShop;
 import org.maxgamer.QuickShop.Database.Database;
@@ -402,8 +402,8 @@ public class ShopManager {
                             }
                         }
                         signBlockState.setType(Material.OAK_WALL_SIGN);
-                        final Sign sign = (Sign) signBlockState.getData();
-                        sign.setFacingDirection(bf);
+                        org.bukkit.block.data.type.WallSign signBlockDataType = (org.bukkit.block.data.type.WallSign) signBlockState.getBlockData();
+                        signBlockDataType.setFacing(bf);
                         signBlockState.update(true);
                         shop.setSignText();
                     }

--- a/src/main/java/org/maxgamer/QuickShop/Util/Util.java
+++ b/src/main/java/org/maxgamer/QuickShop/Util/Util.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.*;
+import org.bukkit.block.data.Directional;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -588,20 +590,13 @@ public class Util {
      * @return The block the sign is attached to
      */
     public static Block getAttached(Block b) {
-        try {
-            final Sign sign = (Sign) b.getState().getData(); // Throws a NPE
-                                                             // sometimes??
-            final BlockFace attached = sign.getAttachedFace();
-
-            if (attached == null) {
-                return null;
-            }
-            return b.getRelative(attached);
-        } catch (final NullPointerException e) {
-            return null; // /Not sure what causes this.
+        if (b.getBlockData() instanceof Directional) {
+            Directional directional = (Directional) b.getBlockData();
+            return b.getRelative(directional.getFacing().getOppositeFace());
+        } else {
+            return null;
         }
     }
-
     /**
      * Counts the number of items in the given inventory where
      * Util.matches(inventory item, item) is true.

--- a/src/main/java/org/maxgamer/QuickShop/Util/Util.java
+++ b/src/main/java/org/maxgamer/QuickShop/Util/Util.java
@@ -597,6 +597,7 @@ public class Util {
             return null;
         }
     }
+    
     /**
      * Counts the number of items in the given inventory where
      * Util.matches(inventory item, item) is true.


### PR DESCRIPTION
Replaced 1.13 "Sign" depreciated code using getData() to use 1.14 WallSign and getBlockData() instead. This allows for the signs to show up when creating a new QS chest as well as making existing QS chests functioning again in 1.14. 